### PR TITLE
Add packages: write permission to release build job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: f0
     permissions:
       contents: write
+      packages: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:


### PR DESCRIPTION
The `build` job in `release.yml` pushes container images to `ghcr.io`, but its `permissions` block only granted `contents: write`. When a workflow job declares an explicit `permissions` block, `GITHUB_TOKEN` is restricted to **only** the listed scopes — everything else is denied. Without `packages: write`, the `ghcr.io` push fails.

This is the same failure seen in kubedb/milvus (e.g. https://github.com/kubedb/milvus/actions/runs/29152110532/job/86543132939), which was fixed by adding `packages: write` to the build job.

This PR adds `packages: write` alongside `contents: write`.